### PR TITLE
Make job option application_headers optional

### DIFF
--- a/src/Queue/RabbitMqQueue.php
+++ b/src/Queue/RabbitMqQueue.php
@@ -53,7 +53,10 @@ class RabbitMqQueue extends AbstractQueue implements RabbitMqQueueInterface
     {
         $options = array_merge($this->defaultMessageOptions, $options);
         $message = new AMQPMessage($this->serializeJob($job), $options);
-        $message->set('application_headers', new AMQPTable($options['application_headers']));
+
+        if (isset($options['application_headers'])) {
+            $message->set('application_headers', new AMQPTable($options['application_headers']));
+        }
 
         $this->getChannel()->basic_publish($message, $this->getName());
     }

--- a/tests/Queue/RabbitMqQueueTest.php
+++ b/tests/Queue/RabbitMqQueueTest.php
@@ -128,6 +128,19 @@ class RabbitMqQueueTest extends TestCase
         );
     }
 
+    public function testPushWhenApplicationHeadersNotSet(): void
+    {
+        $this->channel->expects($this->once())->method('basic_publish')->with($this->callback(
+            function (AMQPMessage $message) {
+                $this->assertFalse($message->has('application_headers'));
+
+                return true;
+            })
+        );
+
+        $this->rabbitMqQueue->push($this->createJobMock(123, []));
+    }
+
     public function testPopWhenNoMessageInQueue(): void
     {
         $this->channel->method('basic_get');


### PR DESCRIPTION
application_headers key in AMQP message options is necessary for routing, but not all pushed jobs need to be routed somewhere. The key application_headers should be optional