### PR TITLE
Deprecate Interop\Container\ContainerInterface

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,6 @@
         "laminas/laminas-eventmanager": "^3.2",
         "laminas/laminas-servicemanager": "^3.3",
         "laminas/laminas-mvc": "^3.1",
-        "container-interop/container-interop": "^1.2",
         "php-amqplib/php-amqplib": "^3.1",
         "slm/queue": "^3.0",
         "psr/log": "^1.1"

--- a/src/ConfigFactory.php
+++ b/src/ConfigFactory.php
@@ -3,7 +3,7 @@
 namespace SlmQueueRabbitMq;
 
 use Laminas\ServiceManager\Factory\FactoryInterface;
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 
 class ConfigFactory implements FactoryInterface
 {

--- a/src/Factory/RabbitMqQueueFactory.php
+++ b/src/Factory/RabbitMqQueueFactory.php
@@ -2,11 +2,11 @@
 
 namespace SlmQueueRabbitMq\Factory;
 
+use Psr\Container\ContainerInterface;
 use SlmQueue\Job\JobPluginManager;
 use SlmQueueRabbitMq\Connection\Connection;
 use SlmQueueRabbitMq\Queue\RabbitMqQueue;
 use SlmQueueRabbitMq\Options\RabbitMqOptions;
-use Interop\Container\ContainerInterface;
 use Laminas\ServiceManager\Factory\FactoryInterface;
 
 class RabbitMqQueueFactory implements FactoryInterface

--- a/src/Factory/RabbitMqWorkerFactory.php
+++ b/src/Factory/RabbitMqWorkerFactory.php
@@ -2,7 +2,7 @@
 
 namespace SlmQueueRabbitMq\Factory;
 
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 use SlmQueue\Factory\WorkerAbstractFactory;


### PR DESCRIPTION
> Starting Feb. 13th 2017, container-interop is officially deprecated in favor of PSR-11.

Given that [ContainerInterop's README](https://github.com/container-interop/container-interop#readme) starts off with the statement above, it makes sense to deprecate the package in favour of `Psr\Container\ContainerInterface`, which this change does.