### PR TITLE
Integrate phpcs and phpcbf support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,9 @@
         "psr/log": "^1.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.5"
+        "phpunit/phpunit": "^9.5",
+        "squizlabs/php_codesniffer": "^3.6",
+        "laminas/laminas-coding-standard": "^2.3"
     },
     "autoload": {
         "psr-4": {
@@ -39,5 +41,9 @@
         "psr-4": {
             "SlmQueueRabbitMqTest\\": "test"
         }
+    },
+    "scripts": {
+        "cs-check": "phpcs",
+        "cs-fix": "phpcbf"
     }
 }

--- a/config/module.config.php
+++ b/config/module.config.php
@@ -1,39 +1,40 @@
 <?php
 
+declare(strict_types=1);
+
+use Laminas\ServiceManager\Factory\InvokableFactory;
 use SlmQueueRabbitMq\ConfigFactory;
+use SlmQueueRabbitMq\Factory\RabbitMqWorkerFactory;
 use SlmQueueRabbitMq\Strategy\IdleNapStrategy;
 use SlmQueueRabbitMq\Worker\RabbitMqWorker;
-use SlmQueueRabbitMq\Factory\RabbitMqWorkerFactory;
-use Laminas\ServiceManager\Factory\InvokableFactory;
 
 return [
-    'slm_queue' => [
+    'slm_queue'          => [
         'worker_strategies' => [
             'default' => [
                 IdleNapStrategy::class => ['nap_duration' => 1],
             ],
-            'queues' => [
-            ],
+            'queues'  => [],
         ],
-        'strategy_manager' => [
+        'strategy_manager'  => [
             'factories' => [
                 IdleNapStrategy::class => InvokableFactory::class,
             ],
         ],
-        'worker_manager' => [
+        'worker_manager'    => [
             'factories' => [
                 RabbitMqWorker::class => RabbitMqWorkerFactory::class,
             ],
         ],
     ],
-    'service_manager' => [
+    'service_manager'    => [
         'factories' => [
             'SlmQueueRabbitMq\Config' => ConfigFactory::class,
         ],
     ],
     'slm-queue-rabbitmq' => [
         //Set a logger accessible via service manager for logging exceptions that happened during job execution
-        'logger' => 'MvLogger\Errors',
+        'logger'                  => 'MvLogger\Errors',
         'default_message_options' => [
             // see PhpAmqpLib\Message\AMQPMessage::propertyDefinitions message array for possible options
 //            'delivery_mode' => \PhpAmqpLib\Message\AMQPMessage::DELIVERY_MODE_PERSISTENT,

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<ruleset name="Coding Standard">
+  <rule ref="PSR2"/>
+  <rule ref="PSR12"/>
+
+  <arg name="basepath" value="."/>
+  <arg name="cache" value=".phpcs-cache"/>
+  <arg name="colors"/>
+  <arg name="extensions" value="php"/>
+  <arg name="parallel" value="80"/>
+
+  <!-- Show progress -->
+  <arg value="p"/>
+
+  <!-- Paths to check -->
+  <file>config</file>
+  <file>src</file>
+  <file>tests</file>
+
+  <!-- Include all rules from the Laminas Coding Standard -->
+  <rule ref="LaminasCodingStandard"/>
+</ruleset>
+

--- a/src/ConfigFactory.php
+++ b/src/ConfigFactory.php
@@ -1,16 +1,18 @@
 <?php
 
+declare(strict_types=1);
+
 namespace SlmQueueRabbitMq;
 
-use Laminas\ServiceManager\Factory\FactoryInterface;
 use Interop\Container\ContainerInterface;
+use Laminas\ServiceManager\Factory\FactoryInterface;
 
 class ConfigFactory implements FactoryInterface
 {
     /**
-     * @inheritdoc
+     * @inheritDoc
      */
-    public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
+    public function __invoke(ContainerInterface $container, $requestedName, ?array $options = null)
     {
         return $container->get('config')['slm-queue-rabbitmq'];
     }

--- a/src/Connection/Connection.php
+++ b/src/Connection/Connection.php
@@ -1,16 +1,22 @@
 <?php
 
+declare(strict_types=1);
+
 namespace SlmQueueRabbitMq\Connection;
 
+use Exception;
 use PhpAmqpLib\Connection\AMQPLazyConnection;
 
+/**
+ * phpcs:disable WebimpressCodingStandard.NamingConventions.ValidVariableName
+ */
 class Connection extends AMQPLazyConnection
 {
     /** @var bool */
     private $connectionBlocked = false;
 
     /**
-     * @inheritdoc
+     * @inheritDoc
      */
     public function __construct(
         string $host,
@@ -49,9 +55,9 @@ class Connection extends AMQPLazyConnection
             $ssl_protocol
         );
 
-        $this->set_connection_block_handler(function() {
+        $this->set_connection_block_handler(function () {
             $this->connectionBlocked = true;
-            throw new \Exception('connection.blocked is sent from the server');
+            throw new Exception('connection.blocked is sent from the server');
         });
     }
 

--- a/src/Factory/RabbitMqQueueFactory.php
+++ b/src/Factory/RabbitMqQueueFactory.php
@@ -1,39 +1,37 @@
 <?php
 
+declare(strict_types=1);
+
 namespace SlmQueueRabbitMq\Factory;
 
-use SlmQueue\Job\JobPluginManager;
-use SlmQueueRabbitMq\Connection\Connection;
-use SlmQueueRabbitMq\Queue\RabbitMqQueue;
-use SlmQueueRabbitMq\Options\RabbitMqOptions;
 use Interop\Container\ContainerInterface;
 use Laminas\ServiceManager\Factory\FactoryInterface;
+use SlmQueue\Job\JobPluginManager;
+use SlmQueueRabbitMq\Connection\Connection;
+use SlmQueueRabbitMq\Options\RabbitMqOptions;
+use SlmQueueRabbitMq\Queue\RabbitMqQueue;
 
 class RabbitMqQueueFactory implements FactoryInterface
 {
     /**
      * {@inheritDoc}
+     *
      * @return RabbitMqQueue
      */
-    public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
+    public function __invoke(ContainerInterface $container, $requestedName, ?array $options = null)
     {
-        $connection = $this->createConnection($container, $requestedName);
-        $jobPluginManager = $container->get(JobPluginManager::class);
+        $connection            = $this->createConnection($container, $requestedName);
+        $jobPluginManager      = $container->get(JobPluginManager::class);
         $defaultMessageOptions = $container->get('SlmQueueRabbitMq\Config')['default_message_options'];
 
         return new RabbitMqQueue($connection, $requestedName, $jobPluginManager, $defaultMessageOptions);
     }
 
-    /**
-     * @param ContainerInterface $container
-     * @param string $queueName
-     * @return Connection
-     */
     protected function createConnection(ContainerInterface $container, string $queueName): Connection
     {
-        $allOptionsArray = $container->get('config')['slm_queue']['queues'];
+        $allOptionsArray   = $container->get('config')['slm_queue']['queues'];
         $queueOptionsArray = $allOptionsArray[$queueName];
-        $options = new RabbitMqOptions($queueOptionsArray['connection']);
+        $options           = new RabbitMqOptions($queueOptionsArray['connection']);
 
         return new Connection(
             $options->getHost(),

--- a/src/Factory/RabbitMqWorkerFactory.php
+++ b/src/Factory/RabbitMqWorkerFactory.php
@@ -1,8 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 namespace SlmQueueRabbitMq\Factory;
 
 use Interop\Container\ContainerInterface;
+use Laminas\EventManager\EventManager;
+use Laminas\ServiceManager\Factory\FactoryInterface;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 use SlmQueue\Factory\WorkerAbstractFactory;
@@ -10,13 +14,11 @@ use SlmQueue\Strategy\StrategyPluginManager;
 use SlmQueue\Worker\WorkerInterface;
 use SlmQueueRabbitMq\Job\MessageRetryCounter;
 use SlmQueueRabbitMq\Worker\RabbitMqWorker;
-use Laminas\EventManager\EventManager;
-use Laminas\ServiceManager\Factory\FactoryInterface;
 
 class RabbitMqWorkerFactory extends WorkerAbstractFactory implements FactoryInterface
 {
     /**
-     * @inheritdoc
+     * @inheritDoc
      * @return RabbitMqWorker
      */
     public function __invoke(ContainerInterface $container, $requestedName, ?array $options = null): WorkerInterface
@@ -24,9 +26,9 @@ class RabbitMqWorkerFactory extends WorkerAbstractFactory implements FactoryInte
         /** @var EventManager $eventManager */
         $eventManager = $container->has('EventManager') ? $container->get('EventManager') : new EventManager();
 
-        $slmConfig = $container->get('config')['slm_queue'];
+        $slmConfig       = $container->get('config')['slm_queue'];
         $allOptionsArray = $slmConfig['queues'];
-        $strategies = $slmConfig['worker_strategies']['default'];
+        $strategies      = $slmConfig['worker_strategies']['default'];
 
         $listenerPluginManager = $container->get(StrategyPluginManager::class);
         $this->attachWorkerListeners($eventManager, $listenerPluginManager, $strategies);

--- a/src/Job/MessageRetryCounter.php
+++ b/src/Job/MessageRetryCounter.php
@@ -1,9 +1,13 @@
 <?php
 
+declare(strict_types=1);
+
 namespace SlmQueueRabbitMq\Job;
 
 use PhpAmqpLib\Wire\AMQPTable;
 use SlmQueue\Job\JobInterface;
+
+use function current;
 
 class MessageRetryCounter
 {
@@ -18,32 +22,18 @@ class MessageRetryCounter
         $this->options = $options;
     }
 
-    /**
-     * @param JobInterface $job
-     * @param string $queueName
-     * @return bool
-     */
     public function canRetry(JobInterface $job, string $queueName): bool
     {
-        return $this->isRetryEnabled($queueName) && !$this->isRetryLimitReached($job, $queueName);
+        return $this->isRetryEnabled($queueName) && ! $this->isRetryLimitReached($job, $queueName);
     }
 
-    /**
-     * @param JobInterface $job
-     * @param string $queueName
-     * @return bool
-     */
     private function isRetryLimitReached(JobInterface $job, string $queueName): bool
     {
         $options = $this->getQueueOptions($queueName);
 
-        return $this->getCountOfDeath($job->getMetadata()) >= (int)$options['retry_limit'];
+        return $this->getCountOfDeath($job->getMetadata()) >= (int) $options['retry_limit'];
     }
 
-    /**
-     * @param string $queueName
-     * @return bool
-     */
     private function isRetryEnabled(string $queueName): bool
     {
         return $this->getQueueOptions($queueName)['retry_limit'] > 0;
@@ -51,7 +41,6 @@ class MessageRetryCounter
 
     /**
      * @param array $metadata
-     * @return int
      */
     private function getCountOfDeath(array $metadata): int
     {
@@ -65,11 +54,10 @@ class MessageRetryCounter
 
     /**
      * @param array $metadata
-     * @return null|AMQPTable
      */
     private function getMessageHeaders(array $metadata): ?AMQPTable
     {
-        if (!empty($metadata['application_headers'])) {
+        if (! empty($metadata['application_headers'])) {
             return $metadata['application_headers'];
         }
 
@@ -85,7 +73,7 @@ class MessageRetryCounter
         $deathInfo = null;
 
         $headers = $this->getMessageHeaders($metadata);
-        if ($headers && !empty($headers->getNativeData()['x-death'])) {
+        if ($headers && ! empty($headers->getNativeData()['x-death'])) {
             $deathInfo = $headers->getNativeData()['x-death'];
         }
 
@@ -93,7 +81,6 @@ class MessageRetryCounter
     }
 
     /**
-     * @param string $queueName
      * @return array
      */
     private function getQueueOptions(string $queueName): array

--- a/src/Module.php
+++ b/src/Module.php
@@ -1,15 +1,16 @@
 <?php
 
+declare(strict_types=1);
+
 namespace SlmQueueRabbitMq;
 
-use Laminas\Console\Adapter\AdapterInterface;
 use Laminas\ModuleManager\Feature\ConfigProviderInterface;
 use Laminas\ModuleManager\Feature\DependencyIndicatorInterface;
 
 class Module implements ConfigProviderInterface, DependencyIndicatorInterface
 {
     /**
-     * @inheritdoc
+     * @inheritDoc
      */
     public function getConfig()
     {
@@ -17,7 +18,7 @@ class Module implements ConfigProviderInterface, DependencyIndicatorInterface
     }
 
     /**
-     * @inheritdoc
+     * @inheritDoc
      */
     public function getModuleDependencies()
     {

--- a/src/Options/RabbitMqOptions.php
+++ b/src/Options/RabbitMqOptions.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace SlmQueueRabbitMq\Options;
 
 use Laminas\Stdlib\AbstractOptions;
@@ -24,16 +26,12 @@ class RabbitMqOptions extends AbstractOptions
     /** @var float */
     protected $channelRpcTimeout;
 
-    /**
-     * @return string
-     */
     public function getHost(): string
     {
         return $this->host;
     }
 
     /**
-     * @param string $host
      * @return $this
      */
     public function setHost(string $host)
@@ -43,16 +41,12 @@ class RabbitMqOptions extends AbstractOptions
         return $this;
     }
 
-    /**
-     * @return int
-     */
     public function getPort(): int
     {
         return $this->port;
     }
 
     /**
-     * @param int $port
      * @return $this
      */
     public function setPort(int $port)
@@ -62,16 +56,12 @@ class RabbitMqOptions extends AbstractOptions
         return $this;
     }
 
-    /**
-     * @return string
-     */
     public function getUser(): string
     {
         return $this->user;
     }
 
     /**
-     * @param string $user
      * @return $this
      */
     public function setUser(string $user)
@@ -81,16 +71,12 @@ class RabbitMqOptions extends AbstractOptions
         return $this;
     }
 
-    /**
-     * @return string
-     */
     public function getVhost(): string
     {
         return $this->vhost;
     }
 
     /**
-     * @param string $vhost
      * @return $this
      */
     public function setVhost(string $vhost)
@@ -100,16 +86,12 @@ class RabbitMqOptions extends AbstractOptions
         return $this;
     }
 
-    /**
-     * @return string
-     */
     public function getPassword(): string
     {
         return $this->password;
     }
 
     /**
-     * @param string $password
      * @return $this
      */
     public function setPassword(string $password)

--- a/src/Queue/RabbitMqQueue.php
+++ b/src/Queue/RabbitMqQueue.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace SlmQueueRabbitMq\Queue;
 
 use PhpAmqpLib\Channel\AMQPChannel as Channel;
@@ -10,6 +12,8 @@ use SlmQueue\Job\JobInterface;
 use SlmQueue\Job\JobPluginManager;
 use SlmQueue\Queue\AbstractQueue;
 use SlmQueueRabbitMq\Worker\RabbitMqWorker;
+
+use function array_merge;
 
 class RabbitMqQueue extends AbstractQueue implements RabbitMqQueueInterface
 {
@@ -22,12 +26,11 @@ class RabbitMqQueue extends AbstractQueue implements RabbitMqQueueInterface
     /** @var array */
     private $defaultMessageOptions;
 
+    /** @var string */
     protected static $defaultWorkerName = RabbitMqWorker::class;
 
     /**
-     * @param Connection $connection
      * @param string $name
-     * @param JobPluginManager $jobPluginManager
      * @param array $defaultMessageOptions
      */
     public function __construct(
@@ -36,7 +39,7 @@ class RabbitMqQueue extends AbstractQueue implements RabbitMqQueueInterface
         JobPluginManager $jobPluginManager,
         array $defaultMessageOptions
     ) {
-        $this->connection = $connection;
+        $this->connection            = $connection;
         $this->defaultMessageOptions = $defaultMessageOptions;
 
         parent::__construct($name, $jobPluginManager);
@@ -50,7 +53,7 @@ class RabbitMqQueue extends AbstractQueue implements RabbitMqQueueInterface
     }
 
     /**
-     * @inheritdoc
+     * @inheritDoc
      */
     public function push(JobInterface $job, array $options = []): void
     {
@@ -65,14 +68,14 @@ class RabbitMqQueue extends AbstractQueue implements RabbitMqQueueInterface
     }
 
     /**
-     * @inheritdoc
+     * @inheritDoc
      * @return JobInterface|null
      */
     public function pop(array $options = []): ?JobInterface
     {
-        $prefetchSize = null;
+        $prefetchSize  = null;
         $prefetchCount = 1;
-        $aGlobal = null;
+        $aGlobal       = null;
 
         $this->getChannel()->basic_qos($prefetchSize, $prefetchCount, $aGlobal);
 
@@ -92,7 +95,7 @@ class RabbitMqQueue extends AbstractQueue implements RabbitMqQueueInterface
     }
 
     /**
-     * @inheritdoc
+     * @inheritDoc
      */
     public function delete(JobInterface $job): void
     {
@@ -100,7 +103,7 @@ class RabbitMqQueue extends AbstractQueue implements RabbitMqQueueInterface
     }
 
     /**
-     * @inheritdoc
+     * @inheritDoc
      */
     public function release(JobInterface $job, array $options = [])
     {
@@ -108,19 +111,16 @@ class RabbitMqQueue extends AbstractQueue implements RabbitMqQueueInterface
     }
 
     /**
-     * @inheritdoc
+     * @inheritDoc
      */
     public function bury(JobInterface $job, array $options = [])
     {
         $this->getChannel()->basic_reject($job->getId(), false);
     }
 
-    /**
-     * @return Channel
-     */
     private function getChannel(): Channel
     {
-        if (!$this->channel) {
+        if (! $this->channel) {
             $this->channel = $this->connection->channel();
         }
 

--- a/src/Queue/RabbitMqQueueInterface.php
+++ b/src/Queue/RabbitMqQueueInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace SlmQueueRabbitMq\Queue;
 
 use SlmQueue\Job\JobInterface;
@@ -10,7 +12,6 @@ interface RabbitMqQueueInterface extends QueueInterface
     /**
      * Put a job that was popped back to the queue
      *
-     * @param  JobInterface $job
      * @param  array        $options
      * @return void
      */
@@ -19,7 +20,6 @@ interface RabbitMqQueueInterface extends QueueInterface
     /**
      * Bury a job. When a job is buried, it won't be retrieved from the queue
      *
-     * @param  JobInterface $job
      * @param  array        $options
      * @return void
      */

--- a/src/Strategy/IdleNapStrategy.php
+++ b/src/Strategy/IdleNapStrategy.php
@@ -1,12 +1,16 @@
 <?php
 
+declare(strict_types=1);
+
 namespace SlmQueueRabbitMq\Strategy;
 
+use Laminas\EventManager\EventManagerInterface;
 use SlmQueue\Strategy\AbstractStrategy;
 use SlmQueue\Worker\Event\AbstractWorkerEvent;
 use SlmQueue\Worker\Event\ProcessIdleEvent;
 use SlmQueueRabbitMq\Queue\RabbitMqQueueInterface;
-use Laminas\EventManager\EventManagerInterface;
+
+use function sleep;
 
 class IdleNapStrategy extends AbstractStrategy
 {
@@ -45,9 +49,6 @@ class IdleNapStrategy extends AbstractStrategy
         );
     }
 
-    /**
-     * @param ProcessIdleEvent $event
-     */
     public function onIdle(ProcessIdleEvent $event)
     {
         $queue = $event->getQueue();

--- a/src/Worker/RabbitMqWorker.php
+++ b/src/Worker/RabbitMqWorker.php
@@ -1,7 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 namespace SlmQueueRabbitMq\Worker;
 
+use Exception;
+use Laminas\EventManager\EventManagerInterface;
 use Psr\Log\LoggerInterface;
 use SlmQueue\Job\JobInterface;
 use SlmQueue\Queue\QueueInterface;
@@ -9,9 +13,7 @@ use SlmQueue\Worker\AbstractWorker;
 use SlmQueue\Worker\Event\ProcessJobEvent;
 use SlmQueueRabbitMq\Job\MessageRetryCounter;
 use SlmQueueRabbitMq\Queue\RabbitMqQueueInterface;
-use Laminas\EventManager\EventManagerInterface;
 use Throwable;
-use Exception;
 
 class RabbitMqWorker extends AbstractWorker
 {
@@ -21,30 +23,24 @@ class RabbitMqWorker extends AbstractWorker
     /** @var LoggerInterface */
     private $logger;
 
-    /**
-     * @param EventManagerInterface $eventManager
-     * @param MessageRetryCounter $retryCounter
-     * @param LoggerInterface $logger
-     */
     public function __construct(
         EventManagerInterface $eventManager,
         MessageRetryCounter $retryCounter,
         LoggerInterface $logger
-    )
-    {
+    ) {
         parent::__construct($eventManager);
 
         $this->retryCounter = $retryCounter;
-        $this->logger = $logger;
+        $this->logger       = $logger;
     }
 
     /**
-     * @inheritdoc
+     * @inheritDoc
      * @return int
      */
     public function processJob(JobInterface $job, QueueInterface $queue): int
     {
-        if (!$queue instanceof RabbitMqQueueInterface) {
+        if (! $queue instanceof RabbitMqQueueInterface) {
             return ProcessJobEvent::JOB_STATUS_FAILURE;
         }
 
@@ -69,14 +65,13 @@ class RabbitMqWorker extends AbstractWorker
     }
 
     /**
-     * @param Throwable $exception
      * @return array
      */
     public function createExceptionParams(Throwable $exception): array
     {
         return [
-            'exception' => new Exception($exception->getMessage(), $exception->getCode(), $exception),
-            'stack_trace' => $exception->getTraceAsString()
+            'exception'   => new Exception($exception->getMessage(), $exception->getCode(), $exception),
+            'stack_trace' => $exception->getTraceAsString(),
         ];
     }
 }

--- a/tests/Job/MessageRetryCounterTest.php
+++ b/tests/Job/MessageRetryCounterTest.php
@@ -1,12 +1,17 @@
 <?php
 
+declare(strict_types=1);
+
 namespace SlmQueueRabbitMqTest\Job;
 
 use PhpAmqpLib\Wire\AMQPTable;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use ReflectionException;
 use SlmQueue\Job\JobInterface;
 use SlmQueueRabbitMq\Job\MessageRetryCounter;
+
+use function array_merge;
 
 class MessageRetryCounterTest extends TestCase
 {
@@ -43,7 +48,7 @@ class MessageRetryCounterTest extends TestCase
 
     public function testCanRetryWhenMessageIsDeadFirstTime()
     {
-        $headers = new AMQPTable(['x-death' => [['count' => 1,],],]);
+        $headers = new AMQPTable(['x-death' => [['count' => 1]]]);
 
         $job = $this->createJobMock(['application_headers' => $headers]);
 
@@ -52,7 +57,7 @@ class MessageRetryCounterTest extends TestCase
 
     public function testCanRetryWhenRetryLimitReached()
     {
-        $headers = new AMQPTable(['x-death' => [['count' => 2,],],]);
+        $headers = new AMQPTable(['x-death' => [['count' => 2]]]);
 
         $job = $this->createJobMock(['application_headers' => $headers]);
 
@@ -75,14 +80,14 @@ class MessageRetryCounterTest extends TestCase
     /**
      * @param array $headers
      * @return JobInterface|MockObject
-     * @throws \ReflectionException
+     * @throws ReflectionException
      */
     private function createJobMock(array $headers)
     {
         /** @var JobInterface|MockObject $job */
         $job = $this->createMock(JobInterface::class);
         $job->method('getMetadata')->willReturn(array_merge(
-            ['__name__' => 'some_job_class_fqn',],
+            ['__name__' => 'some_job_class_fqn'],
             $headers
         ));
 

--- a/tests/Worker/RabbitMqWorkerTest.php
+++ b/tests/Worker/RabbitMqWorkerTest.php
@@ -1,10 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 namespace SlmQueueRabbitMqTest\Worker;
 
-use TypeError;
 use Exception;
-use Throwable;
+use Laminas\EventManager\EventManagerInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
@@ -14,7 +15,8 @@ use SlmQueue\Worker\Event\ProcessJobEvent;
 use SlmQueueRabbitMq\Job\MessageRetryCounter;
 use SlmQueueRabbitMq\Queue\RabbitMqQueueInterface;
 use SlmQueueRabbitMq\Worker\RabbitMqWorker;
-use Laminas\EventManager\EventManagerInterface;
+use Throwable;
+use TypeError;
 
 class RabbitMqWorkerTest extends TestCase
 {
@@ -32,9 +34,9 @@ class RabbitMqWorkerTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->eventManager = $this->createMock(EventManagerInterface::class);
+        $this->eventManager        = $this->createMock(EventManagerInterface::class);
         $this->messageRetryCounter = $this->createMock(MessageRetryCounter::class);
-        $this->logger = $this->createMock(LoggerInterface::class);
+        $this->logger              = $this->createMock(LoggerInterface::class);
 
         $this->rabbitMqWorker = new RabbitMqWorker($this->eventManager, $this->messageRetryCounter, $this->logger);
     }
@@ -74,7 +76,7 @@ class RabbitMqWorkerTest extends TestCase
     {
         /** @var JobInterface|MockObject $job */
         $job = $this->createMock(JobInterface::class);
-        $job->method('execute')->willThrowException(new \Exception());
+        $job->method('execute')->willThrowException(new Exception());
         $this->logger->expects($this->once())->method('error');
         /** @var QueueInterface|MockObject $queue */
         $queue = $this->createMock(RabbitMqQueueInterface::class);
@@ -96,8 +98,7 @@ class RabbitMqWorkerTest extends TestCase
         $job = $this->createMock(JobInterface::class);
         $job->method('execute')->will($this->throwException($originalException));
         $this->logger->expects($this->once())->method('warning')->willReturnCallback(
-            function ($message, array $context = array()) use ($originalException)
-            {
+            function ($message, array $context = []) use ($originalException) {
                 $this->assertInstanceOf(Exception::class, $context['exception'], 'exception is of correct class type');
                 /** @var Throwable $exception */
                 $exception = $context['exception'];


### PR DESCRIPTION
This PR:

- Adds PHPCS and PHPCBF as development dependencies.
- Adds an initial PHPCS configuration that uses the Laminas, PSR2, and PSR12 coding standards. 
- Adds two Composer scripts, one to run phpcs and the other run phpcbf, so that it's easy to do and to automate.
- Updates both source and test files to bring them in line with the new standards.